### PR TITLE
Removed unnecessary white space from blogs modal

### DIFF
--- a/src/scripts/BlogsModal.js
+++ b/src/scripts/BlogsModal.js
@@ -33,46 +33,6 @@ export default {
           But JavaScript never misses a chance to amaze everyone and handles a Divide by Zero in a different way. Let's see how!
           `,
         },
-        {
-          type: "",
-          heading: "",
-          link: "",
-          description: `
-            
-          `,
-        },
-        {
-          type: "",
-          heading: "",
-          link: "",
-          description: `
-            
-          `,
-        },
-        {
-          type: "",
-          heading: "",
-          link: "",
-          description: `
-            
-          `,
-        },
-        {
-          type: "",
-          heading: "",
-          link: "",
-          description: `
-            
-          `,
-        },
-        {
-          type: "",
-          heading: "",
-          link: "",
-          description: `
-            
-          `,
-        },
       ],
     };
   },
@@ -82,3 +42,11 @@ export default {
     },
   },
 };
+
+// blog json format
+// {
+//   type: "",
+//   heading: "",
+//   link: "",
+//   description: ``,
+// },


### PR DESCRIPTION
What this PR does:
- Removes the blank objects from `BlogsModal.js` that were creating unnecessary white space in the `blogs` modal